### PR TITLE
 :r statements should stay relative to basePath 

### DIFF
--- a/SqlCmd.cs
+++ b/SqlCmd.cs
@@ -242,20 +242,14 @@ namespace com.rusanu.DBUtil {
 		private void RunCommand (string line, string basePath) {
 			Regex regFile = new Regex (@":r\s+(?<file>.+)", RegexOptions.IgnoreCase);
 			var match = regFile.Match (line);
-			if (!match.Success) {
-				return;
-			}
-			var fileMatch = match.Groups ["file"];
-			if (fileMatch == null) {
-				return;
+			string fileMatch = null;
+			if (match.Success) {
+				fileMatch = match.Groups ["file"].Value;
 			}
 
-			var filePath = GetFullFilePath(fileMatch.Value, basePath);
-			if (string.IsNullOrEmpty (filePath) || !File.Exists (filePath)) {
-				return;
-			}
+			var filePath = GetFullFilePath(fileMatch, basePath);
 
-			ExecuteFile (filePath);
+			ExecuteFile (filePath, basePath);
 		}
 
 		private string GetFullFilePath(string filePath, string basePath)


### PR DESCRIPTION
SQLCMD runs nested :r statements relative to the current working directory(basepath). They shouldn't build upon each other.
eg
:r dir1/file.sql

should run ./dir1/file1.sql, which would run another:
:r dir2/file2.sql

should run ./dir2/file2.sql but it was incorrectly running ./dir1/dir2/file2.sql and silently continuing.